### PR TITLE
FEAT: Add global option to download the original file

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,6 +33,7 @@ type Paperless struct {
 	AddQueueTagName  string `validate:"required"`
 	ProcessedTagName string `validate:"required"`
 	Rules            []rule `validate:"required,dive,required"`
+	DownloadOriginal bool   `validate:"boolean"`
 }
 
 type rule struct {
@@ -91,7 +92,6 @@ func RuleValidation(sl validator.StructLevel) {
 
 // LoadConfig function to initialize config
 func LoadConfig() {
-
 	viper.SetConfigName("config")
 	viper.SetConfigType("yaml")
 	viper.AddConfigPath("config/")

--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -3,6 +3,7 @@ Paperless:
   InstanceToken: 9d02951f3716e098b
   ProcessedTagName: DatevSent
   AddQueueTagName: SendToDatev
+  DownloadOriginal: true
   Rules:
     - Name: "OneDemoRule"
       Tags: #The Doc must hold all three tags 

--- a/paperless_api.go
+++ b/paperless_api.go
@@ -328,7 +328,11 @@ func addTagToDocument(document Document, tag Tag) error {
 }
 
 func downloadDocumentBinary(doc Document) ([]byte, error) {
-	url := fmt.Sprintf("%sapi/documents/%d/download/", Config.Paperless.InstanceURL, doc.ID)
+	original := ""
+	if Config.Paperless.DownloadOriginal {
+		original = "?original=true"
+	}
+	url := fmt.Sprintf("%sapi/documents/%d/download/%s", Config.Paperless.InstanceURL, doc.ID, original)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Adds a global option to forward the original files instead of the processed files.
A use case is invoices with XML included like ZUGFERD :)

Uses the global optional option
`DownloadOriginal: true`